### PR TITLE
Use txt as genbank

### DIFF
--- a/gbk_parser.pl
+++ b/gbk_parser.pl
@@ -73,7 +73,7 @@ sub parse_gbk
 		my $gbk_file;
 		
 		# EMBL format
-		if ($gbk_path =~ /\.(dat|embl)$/) {
+		if ($gbk_path =~ /\.(dat|embl|txt)$/) {
 			eval {
 				$gbk_file = Bio::SeqIO->new(
 						-file	=> "<$gbk_path",


### PR DESCRIPTION
To use txt as genbank, we need to also not use intermediate txt files. Put all temp files in a cleaner subdir.